### PR TITLE
Use flipper-activerecord with AR3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 An [ActiveRecord](https://github.com/rails/rails/tree/master/activerecord) adapter for [Flipper](https://github.com/jnunemaker/flipper).
 
 Currently, this targets Rails 4.2 because it uses real foreign keys via
-`add_foreign_key` and `remove_foreign_key`. These can probably easily be added
-with SQL instead, which would make this compatible with more Rails versions.
+`add_foreign_key` and `remove_foreign_key`. You can backport those commands
+using the [Foreigner](https://github.com/matthuhiggins/foreigner) gem to
+drive compatibility with other rails versions.
 
 ## Installation
 

--- a/flipper-activerecord.gemspec
+++ b/flipper-activerecord.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
 
   gem.add_dependency 'flipper', '~> 0.6'
-  gem.add_dependency 'activerecord', '>= 4.2.0.beta2'
+  gem.add_dependency 'activerecord', '>= 3.2.21'
 end

--- a/lib/flipper/adapters/activerecord.rb
+++ b/lib/flipper/adapters/activerecord.rb
@@ -110,7 +110,7 @@ module Flipper
       #
       # Returns true.
       def disable(feature, gate, thing)
-        scope = Flipper::ActiveRecord::Gate.joins(:feature).where(flipper_features: {name: feature.key})
+        scope = gate_join(feature)
 
         g = case gate.data_type
         when :boolean
@@ -136,7 +136,7 @@ module Flipper
       
       # Private
       def gate_join( feature )
-        Flipper::ActiveRecord::Gate.joins(:feature).where( flipper_features: {name: feature.key} )
+        Flipper::ActiveRecord::Gate.joins(:feature).where( flipper_features: {name: feature.key} ).readonly(false)
       end
 
       # Private

--- a/lib/flipper/adapters/activerecord.rb
+++ b/lib/flipper/adapters/activerecord.rb
@@ -44,7 +44,7 @@ module Flipper
       # Returns a Hash of Flipper::Gate#key => value.
       def get(feature)
         result = {}
-        f = Flipper::ActiveRecord::Feature.eager_load(:gates).find_by(name: feature.key)
+        f = Flipper::ActiveRecord::Feature.eager_load(:gates).where(name: feature.key)
 
         feature.gates.each do |gate|
           result[gate.key] = case gate.data_type

--- a/lib/flipper/adapters/activerecord.rb
+++ b/lib/flipper/adapters/activerecord.rb
@@ -24,7 +24,9 @@ module Flipper
 
       # Public: Adds a feature to the set of known features.
       def add(feature)
-        Flipper::ActiveRecord::Feature.find_or_create_by!(name: feature.name.to_s)
+        opts = { name: feature.name.to_s }
+        Flipper::ActiveRecord::Feature.where(opts).first ||
+          Flipper::ActiveRecord::Feature.create!(opts)
         true
       end
 
@@ -77,25 +79,20 @@ module Flipper
       def enable(feature, gate, thing)
         case gate.data_type
         when :boolean, :integer
-          g = Flipper::ActiveRecord::Gate.joins(:feature).
-            where(flipper_features: {name: feature.key}).
-            find_or_initialize_by({
-              name: gate.key.to_s,
-            })
+          g = gate_join( feature )
+          opts = { name: gate.key.to_s }
+          g = g.where(opts).first || g.new(opts)
           g.value = thing.value.to_s
           unless g.persisted?
-            g.feature = Flipper::ActiveRecord::Feature.select(:id).find_or_create_by!(name: feature.key)
+            g.feature = feature_id( feature )
           end
           g.save!
         when :set
-          g = Flipper::ActiveRecord::Gate.joins(:feature).
-            where(flipper_features: {name: feature.key}).
-            find_or_initialize_by({
-              name:  gate.key.to_s,
-              value: thing.value.to_s,
-            })
+          g = gate_join( feature )
+          opts = { name:  gate.key.to_s, value: thing.value.to_s }
+          g = g.where(opts).first || g.new!(opts)
           unless g.persisted?
-            g.feature = Flipper::ActiveRecord::Feature.select(:id).find_or_create_by!(name: feature.key)
+            g.feature = feature_id( feature )
           end
           g.save!
         else
@@ -128,6 +125,18 @@ module Flipper
         end
 
         true
+      end
+      
+      # Private
+      def feature_id( feature )
+        opts = { name: feature.key }
+        i = Flipper::ActiveRecord::Feature.select(:id)
+        i.where(opts).first || i.create!(opts)
+      end
+      
+      # Private
+      def gate_join( feature )
+        Flipper::ActiveRecord::Gate.joins(:feature).where( flipper_features: {name: feature.key} )
       end
 
       # Private

--- a/lib/flipper/adapters/activerecord.rb
+++ b/lib/flipper/adapters/activerecord.rb
@@ -46,7 +46,7 @@ module Flipper
       # Returns a Hash of Flipper::Gate#key => value.
       def get(feature)
         result = {}
-        f = Flipper::ActiveRecord::Feature.eager_load(:gates).where(name: feature.key)
+        f = Flipper::ActiveRecord::Feature.eager_load(:gates).where(name: feature.key).first
 
         feature.gates.each do |gate|
           result[gate.key] = case gate.data_type


### PR DESCRIPTION
Added instructions on how to use flipper-activerecord with activerecord 3.2.21 using the https://github.com/matthuhiggins/foreigner gem.

Still working through the finer details here.
